### PR TITLE
Fix example imports

### DIFF
--- a/examples/frontiermath/project_euler.py
+++ b/examples/frontiermath/project_euler.py
@@ -1,8 +1,12 @@
 from inspect_ai import Task, task
 from inspect_ai.dataset import Sample
 
-from .agent import frontiermath_agent
-from .scorer import verification_code_scorer
+try:
+    from .agent import frontiermath_agent
+    from .scorer import verification_code_scorer
+except ImportError:  # Fallback when running without package context
+    from agent import frontiermath_agent
+    from scorer import verification_code_scorer
 
 
 @task

--- a/examples/frontiermath/scorer.py
+++ b/examples/frontiermath/scorer.py
@@ -14,7 +14,10 @@ from inspect_ai.scorer import (
 from inspect_ai.solver import TaskState
 from inspect_ai.util import sandbox
 
-from .agent import ANSWER_FUNC_TIMEOUT
+try:
+    from .agent import ANSWER_FUNC_TIMEOUT
+except ImportError:  # Fallback when running without package context
+    from agent import ANSWER_FUNC_TIMEOUT
 
 VERIFICATION_CODE_TIMEOUT = 120
 


### PR DESCRIPTION
## Summary
- allow running `examples/frontiermath` without package context

## Testing
- `pytest -q` *(fails: AssertionError: assert 'cancelled' == 'success')*

------
https://chatgpt.com/codex/tasks/task_e_684bfa1e78b883339625b36c6df08903