### PR TITLE
Fix tool registration error

### DIFF
--- a/examples/frontiermath/agent.py
+++ b/examples/frontiermath/agent.py
@@ -78,6 +78,13 @@ def frontiermath_agent(
 
 @tool
 def submit_answer() -> Tool:
+    """Record the final answer function code.
+
+    Provide the code for a function named ``answer`` that returns the
+    solution to the current problem. The code will be stored for scoring
+    and no feedback on correctness is given.
+    """
+
     async def execute(answer_fn_code: str) -> ToolResult:
         store().set("submitted_answer", answer_fn_code)
         return "Your answer has been recorded. No feedback is provided."


### PR DESCRIPTION
## Summary
- add a docstring for `submit_answer` tool to satisfy tool validation

## Testing
- `make check` *(fails: access-member-before-definition)*
- `make test` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_684c096df06883338e8dc210e16820c5