### PR TITLE
Centralize frontiermath submit tool

### DIFF
--- a/examples/frontiermath/agent.py
+++ b/examples/frontiermath/agent.py
@@ -7,8 +7,10 @@ from pydantic import Field
 
 from inspect_ai.model import ChatMessageTool, ChatMessageUser
 from inspect_ai.solver import Generate, Solver, TaskState, solver
-from inspect_ai.tool import ToolFunction, python, tool
+from inspect_ai.tool import ToolFunction, python
 from inspect_ai.util import store
+
+from .submit import submit_answer
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 
@@ -79,18 +81,6 @@ def frontiermath_agent(
     return solve
 
 
-@tool
-def submit_answer(
-    answer: Annotated[
-        int, Field(description="The numeric answer for the current sample")
-    ],
-) -> int:
-    """
-    Record the final answer.
-
-    Returns the same integer so the tool result can be logged.
-    """
-    return answer
 
 
 def insert_tool_call_help_message(state: TaskState) -> TaskState:

--- a/examples/frontiermath/submit.py
+++ b/examples/frontiermath/submit.py
@@ -1,0 +1,11 @@
+from typing import Annotated
+from pydantic import Field
+from inspect_ai.tool import tool
+
+
+@tool
+def submit_answer(
+    answer: Annotated[int, Field(description="The numeric answer to the current sample")]
+) -> int:
+    """The agent calls this once it is confident. Returns the same integer so the framework can log it."""
+    return answer


### PR DESCRIPTION
## Summary
- add `examples/frontiermath/submit.py` with the canonical `submit_answer` tool
- import the tool from `submit.py` in `agent.py`
- remove the previous duplicate `submit_answer` definition

## Testing
- `pytest -k frontiermath -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_684c372e89dc83339e0de91c0abbeed1