### PR TITLE
Fix tool parameter validation in frontiermath agent

### DIFF
--- a/examples/frontiermath/submit.py
+++ b/examples/frontiermath/submit.py
@@ -1,11 +1,22 @@
 from typing import Annotated
+
 from pydantic import Field
+
 from inspect_ai.tool import tool
 
 
 @tool
 def submit_answer(
-    answer: Annotated[int, Field(description="The numeric answer to the current sample")]
+    answer: Annotated[
+        int, Field(description="The numeric answer to the current sample")
+    ],
 ) -> int:
-    """The agent calls this once it is confident. Returns the same integer so the framework can log it."""
+    """The agent calls this once it is confident.
+
+    Args:
+        answer: The numeric answer to the current sample.
+
+    Returns:
+        The submitted answer.
+    """
     return answer


### PR DESCRIPTION
## Summary
- fix `submit_answer` docstring to include parameter description for validation

## Testing
- `make check` *(fails: F821 RunResult undefined)*
- `make test` *(fails: missing packages like httpx)*

------
https://chatgpt.com/codex/tasks/task_e_684c528915648333a9c5f3299f026281