### PR TITLE
Fix: Ensure frontiermath_agent terminates after submission

### DIFF
--- a/examples/frontiermath/submit.py
+++ b/examples/frontiermath/submit.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from pydantic import Field
 
 from inspect_ai.tool import tool
+from inspect_ai.util import store
 
 
 @tool
@@ -19,4 +20,5 @@ def submit_answer(
     Returns:
         The submitted answer.
     """
+    store().set("submitted_answer", answer)
     return answer


### PR DESCRIPTION
The `frontiermath_agent` checks a flag in `inspect_ai.util.store()` (key: "submitted_answer") to determine if an answer has been submitted and whether it should break its processing loop.

However, the mechanism responsible for handling the submission, was not setting this flag. This caused the agent to continue its loop even after a submission, potentially leading to unexpected behavior or hitting token limits.

This commit modifies the submission handling in
`examples/frontiermath/submit.py` to set
`store().set("submitted_answer", answer)` upon successful execution. This allows the agent's existing loop termination logic to function as intended.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
