### PR TITLE
I found a `KeyError` in the `frontiermath` agent.

### DIFF
--- a/examples/frontiermath/agent.py
+++ b/examples/frontiermath/agent.py
@@ -180,7 +180,7 @@ You will be solving a challenging mathematics question. Here's how it works:
    - When scoring your answer, the maximum runtime for the `answer` function is {answer_func_timeout} seconds. The code is executed on typical commodity hardware for the year 2025.
 
    Example final message:
-   {"tool": "submit_answer", "args": {"answer": "def answer():\n    return 123459876"}}
+   {{"tool": "submit_answer", "args": {{"answer": "def answer():\n    return 123459876"}}}}
 7. For using the `python` tool:
     * The tool will only return stdout (and stderr), so you must make sure to
      use print() to see your results. If you don't get any output from a `python` tool call, you


### PR DESCRIPTION
It seems the `TEMPLATE` string in `examples/frontiermath/agent.py` had an example of a tool call in JSON format. The curly braces in this example JSON were causing issues with the f-string formatting, which resulted in a `KeyError: '"tool"'`.

I've fixed this by escaping the curly braces in the example JSON string.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
