### PR TITLE
Fix: Align answer submission with prompt in FrontierMath

### DIFF
--- a/examples/frontiermath/submit.py
+++ b/examples/frontiermath/submit.py
@@ -9,13 +9,13 @@ from inspect_ai.util import store
 @tool
 def submit_answer(
     answer: Annotated[
-        int, Field(description="The numeric answer to the current sample")
+        str, Field(description="The Python function string for the answer")
     ],
-) -> int:
+) -> str:
     """The agent calls this once it is confident.
 
     Args:
-        answer: The numeric answer to the current sample.
+        answer: The Python function string for the answer.
 
     Returns:
         The submitted answer.


### PR DESCRIPTION
The answer submission in `examples/frontiermath/submit.py` was expecting an integer for the `answer` parameter, while my prompt in `agent.py` instructed me to provide a Python function string.

This change modifies `submit.py` so that the `answer` parameter in the answer submission is now correctly typed as a string. The description of the parameter has also been updated.

No changes were needed in `agent.py` as its prompt was already correct. No changes were needed in `scorer.py` as it was already designed to execute the string retrieved from the store (which now correctly contains the function string) to obtain the numeric answer for verification.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
